### PR TITLE
RB_BPWATCHER Kernel Module

### DIFF
--- a/packaging/rpm/redborder-intrusion.spec
+++ b/packaging/rpm/redborder-intrusion.spec
@@ -10,7 +10,7 @@ License: AGPL 3.0
 URL: https://github.com/redBorder/redborder-intrusion
 Source0: %{name}-%{version}.tar.gz
 
-Requires: bash dialog dmidecode rsync nc telnet redborder-common redborder-chef-client redborder-rubyrvm redborder-cli rb-register bridge-utils bpctl net-tools bind-utils ipmitool watchdog bp_watchdog snort3 dhclient
+Requires: bash dialog dmidecode rsync nc telnet redborder-common redborder-chef-client redborder-rubyrvm redborder-cli rb-register bridge-utils bpctl rb_bpwatcher-dkms net-tools bind-utils ipmitool watchdog bp_watchdog snort3 dhclient
 Requires: chef-workstation
 Requires: network-scripts network-scripts-teamd
 Requires: redborder-cgroups

--- a/resources/scripts/rb_init_conf.rb
+++ b/resources/scripts/rb_init_conf.rb
@@ -97,6 +97,19 @@ open("/etc/depmod.d/kmod-redBorder.conf", 'w') { |f|
 system('depmod')
 sleep 3
 
+puts "Loading rb_bpwatcher into kernel..."
+system("systemctl stop rb_bpwatcher")
+system("systemctl start rb_bpwatcher")
+sleep 15
+lsmod_output = `lsmod | grep rb_bpwatcher`
+
+if lsmod_output.strip.empty?
+  puts "Kernel module rb_bpwatcher is NOT loaded."
+else
+  puts "Kernel module rb_bpwatcher is loaded."
+end
+
+
 ####################
 # Set IPMI         #
 ####################


### PR DESCRIPTION
* rb_bpwatcher is a redBorder custom Linux kernel module that controls bp bridges of silicom cards and enable bypass via kernel hook when LINK DOWN event on packet notifier of the kernel -> https://github.com/torvalds/linux/blob/master/net/packet/af_packet.c#L4234